### PR TITLE
ASA-279: Fix package version and remove Node 14

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -31,8 +31,6 @@ body:
       label: What version of Node are you using?
       multiple: false
       options:
-        - Node 14.x
-        - Node 16.x
         - Node 18.x
         - Node 19.x
         - Node 20.x

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -31,6 +31,7 @@ body:
       label: What version of Node are you using?
       multiple: false
       options:
+        - Node 16.x
         - Node 18.x
         - Node 19.x
         - Node 20.x

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["18", "19", "20"]
+        node: ["16", "18", "19", "20"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -5,11 +5,11 @@ on:
     branches: [main]
 
 jobs:
-  python:
+  node:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["14", "16", "18", "19", "20"]
+        node: ["18", "19", "20"]
 
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itscalledsoccer",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "A library for interacting with the ASA API",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
### Description

I didn't realize that `itscalledsoccer-js` had already been published to npmjs so I fixed the package version. I also removed the Node 14 tests based on the EOL for that version of Node. We should do the same thing for Node 19 but since that's a bit more recent I left the tests in there.

https://endoflife.date/nodejs

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if applicable)
- [x] All lint and unit tests passing
- [x] Extended the README / documentation, if necessary

### Additional Comments

Anything else you'd like to add.
