### PR TITLE
Dependabot/npm and yarn/core js 3.32.2

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,7 @@ module.exports = {
       lines: 90,
     },
   },
+  globals: {
+    structuredClone: {}
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "change-case": "^4.1.2",
-        "core-js": "^3.31.0",
+        "core-js": "^3.32.2",
         "fuse.js": "^6.5.3",
         "isomorphic-fetch": "^3.0.0",
         "regenerator-runtime": "^0.14.0"
@@ -3620,9 +3620,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.31.0.tgz",
-      "integrity": "sha512-NIp2TQSGfR6ba5aalZD+ZQ1fSxGhDo/s1w0nx3RYzf2pnJxt7YynxFlFScP6eV7+GZsKO95NSjGxyJsU3DZgeQ==",
+      "version": "3.32.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.2.tgz",
+      "integrity": "sha512-pxXSw1mYZPDGvTQqEc5vgIb83jGQKFGYWY76z4a7weZXUolw3G+OvpZqSRcfYOoOVUQJYEPsWeQK8pKEnUtWxQ==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -10808,9 +10808,9 @@
       }
     },
     "core-js": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.31.0.tgz",
-      "integrity": "sha512-NIp2TQSGfR6ba5aalZD+ZQ1fSxGhDo/s1w0nx3RYzf2pnJxt7YynxFlFScP6eV7+GZsKO95NSjGxyJsU3DZgeQ=="
+      "version": "3.32.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.2.tgz",
+      "integrity": "sha512-pxXSw1mYZPDGvTQqEc5vgIb83jGQKFGYWY76z4a7weZXUolw3G+OvpZqSRcfYOoOVUQJYEPsWeQK8pKEnUtWxQ=="
     },
     "core-js-compat": {
       "version": "3.32.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "change-case": "^4.1.2",
-    "core-js": "^3.31.0",
+    "core-js": "^3.32.2",
     "fuse.js": "^6.5.3",
     "isomorphic-fetch": "^3.0.0",
     "regenerator-runtime": "^0.14.0"


### PR DESCRIPTION
### Description

Bumps [core-js](https://github.com/zloirock/core-js/tree/HEAD/packages/core-js) from 3.31.0 to 3.32.2.

### Checklist

- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if applicable) -- unneccessary, since this fixes an existing test
- [x] All lint and unit tests passing
- [x] Extended the README / documentation, if necessary

### Additional Comments

This supercedes https://github.com/American-Soccer-Analysis/itscalledsoccer-js/pull/29