### PR TITLE
update node versions to match supported versions

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["16", "18", "19", "20"]
+        node: [ "18", "20", "21"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test


### PR DESCRIPTION
### Description

I dropped support for node 16 and 19, and added support for node 21. This brings us back in line with the supported node versions.

This will unblock these prs which are only failing on node 16, a version I've dropped:
- https://github.com/American-Soccer-Analysis/itscalledsoccer-js/pull/49
- https://github.com/American-Soccer-Analysis/itscalledsoccer-js/pull/48

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if applicable)
- [x] All lint and unit tests passing
- [x] Extended the README / documentation, if necessary

### Additional Comments

![node release calendar](https://raw.githubusercontent.com/nodejs/Release/main/schedule.svg?sanitize=true)
